### PR TITLE
Reduce texture path caching time

### DIFF
--- a/3denEnhanced/functions/GUI/textureFinder/fn_textureFinder_findTextures.sqf
+++ b/3denEnhanced/functions/GUI/textureFinder/fn_textureFinder_findTextures.sqf
@@ -63,7 +63,7 @@ private _string = "";
 		{
 			ENH_TextureFinder_TexturesFound pushBackUnique toLower _string;
 		};
-	} forEach configProperties [_x, "isText _x"];
+	} forEach configProperties [_x, "isText _x",false];
 } forEach _classes;
 
 ENH_FindTexture_SearchRunning = nil;


### PR DESCRIPTION
Ignore inherited config properties as they will have already been processed in the original class.

**Processing times**
Before: 57.838 seconds
After: 17.644 seconds