### PR TITLE
Prevent duplicate texture paths where one is missing a leading slash

### DIFF
--- a/3denEnhanced/functions/GUI/textureFinder/fn_textureFinder_findTextures.sqf
+++ b/3denEnhanced/functions/GUI/textureFinder/fn_textureFinder_findTextures.sqf
@@ -61,6 +61,7 @@ private _string = "";
 		_string = getText _x;
 		if (IS_PAA || IS_JPG) then
 		{
+			if (_string find "\" != 0) then {_string = "\" + _string};
 			ENH_TextureFinder_TexturesFound pushBackUnique toLower _string;
 		};
 	} forEach configProperties [_x, "isText _x"];


### PR DESCRIPTION
Some texture paths don't have a leading \ so you can end up with duplicates.

**Unique paths** (with a couple of mods enabled)
Before: 9038
After: 8961

**Example**
Before:
```sqf
"\a3\missions_f_heli\data\img\mp_groundsupport05_overview_ca.paa" in ENH_TextureFinder_TexturesFound; // true
"a3\missions_f_heli\data\img\mp_groundsupport05_overview_ca.paa" in ENH_TextureFinder_TexturesFound; // true
```
After:
```sqf
"\a3\missions_f_heli\data\img\mp_groundsupport05_overview_ca.paa" in ENH_TextureFinder_TexturesFound; // true
"a3\missions_f_heli\data\img\mp_groundsupport05_overview_ca.paa" in ENH_TextureFinder_TexturesFound; // false
```