### PR TITLE
Find texture paths in config arrays

### DIFF
--- a/3denEnhanced/functions/GUI/textureFinder/fn_textureFinder_findTextures.sqf
+++ b/3denEnhanced/functions/GUI/textureFinder/fn_textureFinder_findTextures.sqf
@@ -54,16 +54,28 @@ private _fnc_searchConfig =
 private _classes = [13] call _fnc_searchConfig;
 
 //Check configProperties of every class for textures
-private _string = "";
+private _addPath =  {
+	params ["_string"];
+	if (IS_PAA || IS_JPG) then
+	{
+		ENH_TextureFinder_TexturesFound pushBackUnique toLower _string;
+	};
+};
+private _searchArray = {
+	if (_x isEqualType "") then {_x call _addPath} else {
+		if (_x isEqualType []) then {
+			_searchArray forEach _x;
+		};
+	};
+};
+
 {
 	ENH_TextureFinder_ClassesSearched = ENH_TextureFinder_ClassesSearched + 1;
 	{
-		_string = getText _x;
-		if (IS_PAA || IS_JPG) then
-		{
-			ENH_TextureFinder_TexturesFound pushBackUnique toLower _string;
+		if (isText _x) then {getText _x call _addPath} else {
+			_searchArray forEach getArray _x;
 		};
-	} forEach configProperties [_x, "isText _x"];
+	} forEach configProperties [_x, "isText _x || isArray _x"];
 } forEach _classes;
 
 ENH_FindTexture_SearchRunning = nil;


### PR DESCRIPTION
Some texture paths are inside arrays. This will loop through arrays to find them.

**Unique Paths** (with a couple of mods enabled)
Before: 9038
After: 11029

This will most likely conflict with https://github.com/R3voA3/3den-Enhanced/pull/123 and https://github.com/R3voA3/3den-Enhanced/pull/124 so I'll fix this up if you merge them