### PR TITLE
Fixed variable viewer not deselecting row on variable delete

### DIFF
--- a/3denEnhanced/functions/GUI/variableViewer/fn_variableViewer_delete.sqf
+++ b/3denEnhanced/functions/GUI/variableViewer/fn_variableViewer_delete.sqf
@@ -39,14 +39,12 @@ if (ENH_VariableViewer_Modify_Confirmed) then
   {
     private _LNBData = _ctrlLNB lnbText [_x,0];
     _namespace setVariable [_LNBData,nil];
+    _ctrlLNB lbSetSelected [_x,false];
     _ctrlLNB lnbDeleteRow _x;
   } forEach _selectedRows;
 
   //Reduce variable count by one
   CTRL(IDC_VARIABLEVIEWER_VARIABLECOUNT) ctrlSetText format ["#%1",lnbSize _ctrlLNB select 0];
-
-  //Deselect everything
-  _ctrlLNB lnbSetCurSelRow -1;
 };
 
 ENH_VariableViewer_Modify_Confirmed = nil;


### PR DESCRIPTION
Currently when you delete a variable(s) the row(s) stay selected, only now selecting different variables. This fixes that.
A side effect of this is it no longer moves you back to the top of the list every time you delete a variable (which I think is an improvement).