### PR TITLE
Update fn_exportLoadout.sqf

### DIFF
--- a/3denEnhanced/functions/log/fn_exportLoadout.sqf
+++ b/3denEnhanced/functions/log/fn_exportLoadout.sqf
@@ -53,7 +53,6 @@ private _magsInWeapons = flatten (weaponsItems _object apply {
 
   [_mag, _tube]
 });
-private _magazines = magazines _object;
 private _assignedItems = assigneditems _object;
 private _gear = [vest _object, headgear _object, goggles _object];
 private _export = "";

--- a/3denEnhanced/functions/log/fn_exportLoadout.sqf
+++ b/3denEnhanced/functions/log/fn_exportLoadout.sqf
@@ -32,6 +32,7 @@ private _fnc_addArray =
   params ["_name", "_array"];
   _export = _export + format [IND + "%1[] = {", _name];
   {
+    if (_x == "") then {continue};
     if (_foreachindex > 0) then {_export = _export + ", "};
     _export = _export + format ["""%1""", _x];
   } foreach _array;
@@ -41,16 +42,26 @@ private _fnc_addArray =
 private _class = typeOf _object;
 private _uniformClass = format ["uniformClass = ""%1"";", uniform _object];
 private _backpack = format ["backpack = ""%1"";", backpack _object];
+
 private _weapons = weapons _object;
 private _primWeaponItems = primaryWeaponItems _object;
 private _secWeaponItems = secondaryWeaponItems _object;
+private _handgunItems = handgunItems _object;
+private _magsInWeapons = flatten (weaponsItems _object apply {
+  private _mag = (_x param [4, [], []]) param [0, ""];
+  private _tube = (_x param [5, [], []]) param [0, ""];
+
+  [_mag, _tube]
+});
+private _magazines = magazines _object;
 private _assignedItems = assigneditems _object;
+private _gear = [vest _object, headgear _object, goggles _object];
 private _export = "";
 
 ["weapons", _weapons + ["Throw", "Put"]] call _fnc_addArray;
-["magazines", magazines _object] call _fnc_addArray;
+["magazines", magazines _object + _magsInWeapons] call _fnc_addArray;
 ["items", items _object] call _fnc_addArray;
-["linkedItems", [vest _object, headgear _object, goggles _object] + _assignedItems - _weapons + _primWeaponItems + _secWeaponItems] call _fnc_addArray;
+["linkedItems", _gear + _assignedItems - _weapons + _primWeaponItems + _secWeaponItems + _handgunItems] call _fnc_addArray;
 
 if (_mode) then
 {//Respawn Loadout for config


### PR DESCRIPTION
Line 35: Ignores empty strings for final format.

Lines 49-56: Adds handgun items and magazines that are inside of weapons to the arrays for a correct magazine count.

Note: Due to limitations of CfgRespawnInventory, if a editor overloads a unit's inventory, you will not be able to add additional mags (added at the end of array) from the weapons themselves. This becomes very apparent with large mass rockets.