### PR TITLE
Fix header formatting in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
-#v7.8.5
+# v7.8.5
 ## CHANGED
 - Fixed entity counter
 
-#v7.8.4
+# v7.8.4
 ## CHANGED
 - Move tools from root of context menu into a subfolder so that the context menu is even on very small screen fully accessable
 - Improved display3DENPublishMissionSelectImage
 - Turned version info into a button so it won't overlap on small screens. Clicking the button will show more information about
 current session
 
-#v7.8.3
+# v7.8.3
 ## CHANGED
 - Mission Backup attribute will now create backup files in mission root in a folder called ".enh_mission_sqm_backups". Existing backups will not be moved!
 - Increased 3DEN Radio UI height
@@ -22,7 +22,7 @@ current session
 - Steam Description Generator
 - Create Object Tool
 
-#v7.8.2
+# v7.8.2
 ## ADDED
 
 ## CHANGED


### PR DESCRIPTION
The `#`/`##`/... leaders for headings must have a space after them to work correctly.