### PR TITLE
[Patch] Allow markerHideOnStart to reference original alpha

### DIFF
--- a/3denEnhanced/attributesMarker/markerHideOnStart.hpp
+++ b/3denEnhanced/attributesMarker/markerHideOnStart.hpp
@@ -11,6 +11,7 @@ class ENH_MarkerHideOnStart
       control = "Checkbox";
       expression = "\
         if (!isServer || is3DEN || !_value) exitWith {};\
+        missionNamespace setVariable [format ['ENH_attributesMarker_%1_initAlpha', _this], markerAlpha _this];\
         _this setMarkerAlpha 0";
       defaultValue = "false";
     };
@@ -26,8 +27,9 @@ class ENH_MarkerHideOnStart
         {\
           params ['_marker', '_compiledValue'];\
           scriptName 'ENH_MarkerShowOnCondition';\
-          waitUntil {sleep 1; call _compiledValue};\
-          _marker setMarkerAlpha 1;\
+          waitUntil {sleep 0.5; call _compiledValue};\
+          private _newAlpha = missionNamespace getVariable [format ['ENH_attributesMarker_%1_initAlpha', _this], 1];\
+          _marker setMarkerAlpha _newAlpha;\
         }";
       validate = "expression";
       defaultValue = "''";

--- a/3denEnhanced/attributesMarker/markerHideOnStart.hpp
+++ b/3denEnhanced/attributesMarker/markerHideOnStart.hpp
@@ -28,7 +28,7 @@ class ENH_MarkerHideOnStart
           params ['_marker', '_compiledValue'];\
           scriptName 'ENH_MarkerShowOnCondition';\
           waitUntil {sleep 0.5; call _compiledValue};\
-          private _newAlpha = missionNamespace getVariable [format ['ENH_attributesMarker_%1_initAlpha', _this], 1];\
+          private _newAlpha = missionNamespace getVariable [format ['ENH_attributesMarker_%1_initAlpha', _marker], 1];\
           _marker setMarkerAlpha _newAlpha;\
         }";
       validate = "expression";


### PR DESCRIPTION
## Changes:

- Allows for references original editor alpha instead of restoring alpha to `1`
- Increased rate of conditional check