### PR TITLE
Issues 305

### DIFF
--- a/addons/main/GUI/ESE.hpp
+++ b/addons/main/GUI/ESE.hpp
@@ -109,7 +109,8 @@ class ENH_ESE
                         "SortbyClass",
                         "SortbyCount",
                         "SortbyMod",
-                        "SortbyType"
+                        "SortbyType",
+                        "ImportFromClipboard"
                     };
                 };
                 class FolderFilter
@@ -268,6 +269,12 @@ class ENH_ESE
                     text = "$STR_ENH_MAIN_ESE_SORTBYTYPE";
                     action = "'type' call ENH_fnc_ESE_sort";
                     shortcuts[] = {DIK_5};
+                };
+                class ImportFromClipboard
+                {
+                    text = "$STR_ENH_MAIN_ESE_IMPORTFROMCLIPBOARD";
+                    action = "[false, [], true] call ENH_fnc_ESE_loadAttributeValue";
+                    shortcuts[] = {DIK_6};
                 };
                 //Filter
                 class ARs

--- a/addons/main/cfgFunctions.hpp
+++ b/addons/main/cfgFunctions.hpp
@@ -97,12 +97,14 @@ class CfgFunctions
             class ESE_close;
             class ESE_export;
             class ESE_fullArsenal;
+            class ESE_getConfigValues;
             class ESE_handleTemplates;
             class ESE_lbAdd;
             class ESE_lnbAdd;
             class ESE_loadAttributeValue;
             class ESE_onModFilterChanged;
             class ESE_open;
+            class ESE_parseClipboardValues;
             class ESE_removeItem;
             class ESE_resetSearch;
             class ESE_resetStorage;

--- a/addons/main/functions/GUI/ESE/fn_ESE_applyAttribute.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_applyAttribute.sqf
@@ -8,17 +8,16 @@
 
     Parameter(s):
     0: BOOLEAN - True to not set the attribute and only return the attribute value. Default: false
+    1: ARRAY - Items details. Same data structure as _itemsHashMap.
 
     Returns:
     ARRAY, NOTHING: See Parameters
 */
 
-#include "\x\enh\addons\main\script_component.hpp"
-
+#include "\3denEnhanced\defines\defineCommon.inc"
 disableSerialization;
-params [["_return", false]];
+params [["_return", false], ["_itemsDetails", []]];
 private _display = uiNamespace getVariable "ENH_Display_ESE";
-private _itemsHashMap = uiNamespace getVariable "ENH_ESE_itemsHashMap";
 private _ctrlInventory = CTRL(IDC_ESE_INVENTORYLIST);
 private _rows = lnbSize _ctrlInventory select 0;
 
@@ -32,10 +31,24 @@ private _magazinesAmount = [];
 private _itemsAmount = [];
 private _backpacksAmount = [];
 
+private _itemsHashMap = uiNamespace getVariable "ENH_ESE_itemsHashMap";
+
+private _rowCount = count _itemsDetails;
+if (_rowCount > 0) then {
+    _itemsHashMap = _itemsDetails;
+    _rows = _rowCount
+};
+
 for "_i" from 0 to _rows - 1 do
 {
-    private _configName = _ctrlInventory lnbData [_i, 0];
-    private _amount = _ctrlInventory lnbValue [_i, 1];
+    private "_configName";
+    private _amount = 1;
+    if (_rowCount == 0) then {
+        _configName = _ctrlInventory lnbData [_i, 0];
+        _amount = _ctrlInventory lnbValue [_i, 1]
+    } else {
+        _configName = (keys _itemsHashMap) select _i
+    };
     (_itemsHashMap getOrDefault [toLower _configName, []]) params ["", "", "", "", ["_category", ""], ["_specificType", ""]];
     switch (true) do
     {

--- a/addons/main/functions/GUI/ESE/fn_ESE_applyAttribute.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_applyAttribute.sqf
@@ -14,7 +14,7 @@
     ARRAY, NOTHING: See Parameters
 */
 
-#include "\3denEnhanced\defines\defineCommon.inc"
+#include "\x\enh\addons\main\script_component.hpp"
 disableSerialization;
 params [["_return", false], ["_itemsDetails", []]];
 private _display = uiNamespace getVariable "ENH_Display_ESE";

--- a/addons/main/functions/GUI/ESE/fn_ESE_getConfigValues.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_getConfigValues.sqf
@@ -14,7 +14,7 @@
 */
 
 
-#include "\3denEnhanced\defines\defineCommon.inc"
+#include "\x\enh\addons\main\script_component.hpp"
 #define TYPES_WHITELIST ["AssaultRifle", "MachineGun", "SniperRifle", "Shotgun", "SubmachineGun", "RocketLauncher", "Handgun", "Grenade", "Magazine",\
 "Mine", "AccessoryBipod", "AccessoryMuzzle", "AccessoryPointer", "AccessorySights", "Uniform", "Vest", "Backpack", "Headgear", "Glasses", "NVGoggles", "Item", "MissileLauncher"]
 

--- a/addons/main/functions/GUI/ESE/fn_ESE_getConfigValues.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_getConfigValues.sqf
@@ -14,7 +14,7 @@
 */
 
 
-#include "\x\enh\addons\main\script_component.hpp"
+#include "\3denEnhanced\defines\defineCommon.inc"
 #define TYPES_WHITELIST ["AssaultRifle", "MachineGun", "SniperRifle", "Shotgun", "SubmachineGun", "RocketLauncher", "Handgun", "Grenade", "Magazine",\
 "Mine", "AccessoryBipod", "AccessoryMuzzle", "AccessoryPointer", "AccessorySights", "Uniform", "Vest", "Backpack", "Headgear", "Glasses", "NVGoggles", "Item", "MissileLauncher"]
 

--- a/addons/main/functions/GUI/ESE/fn_ESE_loadAttributeValue.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_loadAttributeValue.sqf
@@ -8,22 +8,30 @@
 
     Parameter(s):
     0: BOOLEAN - Mode. False to load attribute value, true to insert external value
+    1: ARRAY - Attribute data to be applied
+    2: BOOLEAN - True to get attribute vales from clipboard
 
     Returns:
     -
 */
 
-#include "\x\enh\addons\main\script_component.hpp"
+#include "\3denEnhanced\defines\defineCommon.inc"
 disableSerialization;
 
-params [["_loadAttribute", true], ["_attributeValue", []]];
+params [
+    ["_loadAttribute", true],
+    ["_attributeValue", []],
+    ["_fromClipboard", false, [false]]
+];
 
 private _display = uiNamespace getVariable "ENH_Display_ESE";
 private _ctrlInventory = CTRL(IDC_ESE_INVENTORYLIST);
 
 if (_loadAttribute) then
 {
-    _attributeValue = (ENH_ESE_target get3DENAttribute "ammoBox") # 0;
+    _attributeValue = (ENH_ESE_target get3DENAttribute "ammoBox") # 0
+} else {
+    if (_fromClipboard) then {_attributeValue = call ENH_fnc_ESE_parseClipboardValues}
 };
 
 _attributeValue = parseSimpleArray _attributeValue;//Eden saves attributes as string

--- a/addons/main/functions/GUI/ESE/fn_ESE_loadAttributeValue.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_loadAttributeValue.sqf
@@ -15,7 +15,7 @@
     -
 */
 
-#include "\3denEnhanced\defines\defineCommon.inc"
+#include "\x\enh\addons\main\script_component.hpp"
 disableSerialization;
 
 params [

--- a/addons/main/functions/GUI/ESE/fn_ESE_parseClipboardValues.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_parseClipboardValues.sqf
@@ -14,7 +14,7 @@
 */
 
 
-#include "\3denEnhanced\defines\defineCommon.inc"
+#include "\x\enh\addons\main\script_component.hpp"
 private _importList = call compile copyFromClipboard;
 
 // Verify import list is in correct format

--- a/addons/main/functions/GUI/ESE/fn_ESE_parseClipboardValues.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_parseClipboardValues.sqf
@@ -14,8 +14,8 @@
 */
 
 
-#include "\x\enh\addons\main\script_component.hpp"
-private _importList = call compile copyFromClipboard; // Is this safe?
+#include "\3denEnhanced\defines\defineCommon.inc"
+private _importList = call compile copyFromClipboard;
 
 // Verify import list is in correct format
 if (isNil "_importList" || {!(_importList isEqualType [])} || {!(_importList isEqualTypeAll "")}) exitWith {
@@ -41,5 +41,9 @@ private _configs = _importList apply {
     }
 };
 
+//private _configValues = ([_configs] call ENH_fnc_ESE_getConfigValues) select 1;
+//private _attributeValue = [true, _configValues] call ENH_fnc_ESE_applyAttribute;
+//
+//_attributeValue
 private _attributeValue = ([_configs] call ENH_fnc_ESE_getConfigValues) select 1;
 [true, _attributeValue] call ENH_fnc_ESE_applyAttribute

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -7043,7 +7043,7 @@
             <Italian>Ordina per Tipo</Italian>
             <French>Trier par type</French>
         </Key>
-        <Key ID="STR_ENH_ESE_IMPORTFROMCLIPBOARD">
+        <Key ID="STR_ENH_MAIN_ESE_IMPORTFROMCLIPBOARD">
             <English>Import from Clipboard</English>
             <German>Aus der Zwischenablage importieren</German>
             <Chinesesimp>從剪貼簿匯入</Chinesesimp>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -7043,6 +7043,16 @@
             <Italian>Ordina per Tipo</Italian>
             <French>Trier par type</French>
         </Key>
+        <Key ID="STR_ENH_ESE_IMPORTFROMCLIPBOARD">
+            <English>Import from Clipboard</English>
+            <German>Aus der Zwischenablage importieren</German>
+            <Chinesesimp>從剪貼簿匯入</Chinesesimp>
+            <Chinese>从剪贴板导入</Chinese>
+            <Polish>Importuj ze schowka</Polish>
+            <Spanish>Importar desde el portapapeles</Spanish>
+            <Italian>Importa dagli appunti</Italian>
+            <French>Importer depuis le Presse-papiers</French>
+        </Key>
         <Key ID="STR_ENH_MAIN_ESE_SORTBYMOD">
             <English>Sort by Mod</English>
             <German>Nach Modifikation sortieren</German>


### PR DESCRIPTION
Fixed [bug 305](https://github.com/R3voA3/3den-Enhanced/issues/305l).

Tested:
- Open ESE successfully (fn_getAllItems is working)
- Load from template
- Load from clipboard

The change touches on ESE loading only. Since opening and import from clipboard work, the rest should work as expected.

**NOTE:** I saw from the Changelog that `Fixed weapons of type "MissileLauncher" (Titan) would be missing` was fixed. I couldn't locate the code that fixed it and couldn't check. But I saw all Titan launchers showed up in ESE so it might be fine.