### PR TITLE
ESE - Add import from clipboard into Available Items

### DIFF
--- a/addons/main/GUI/ESE.hpp
+++ b/addons/main/GUI/ESE.hpp
@@ -279,6 +279,7 @@ class ENH_ESE
                 {
                     text = "$STR_ENH_MAIN_ESE_IMPORTFROMCLIPBOARD";
                     action = "[false, [], true] call ENH_fnc_ESE_loadAttributeValue";
+                    picture = "\a3\ui_f\data\igui\cfg\actions\loadvehicle_ca.paa";
                     shortcuts[] = {DIK_6};
                 };
                 //Filter
@@ -406,11 +407,13 @@ class ENH_ESE
                 class ImportToFilter
                 {
                     text = "$STR_ENH_MAIN_ESE_IMPORTFROMCLIPBOARD";
+                    picture = "\a3\ui_f\data\igui\cfg\actions\loadvehicle_ca.paa";
                     action = "[] call ENH_fnc_ESE_importToFilter";
                 };
                 class ResetToAllItems
                 {
                     text = "$STR_A3_RSCDISPLAYARSENAL_RESET";
+                    picture = "\A3\ui_f\data\igui\rsctitles\mpprogress\respawn_ca.paa";
                     action = "[] call ENH_fnc_ESE_resetToAllItems";
                 };
                 class InventoryItems: ARs

--- a/addons/main/GUI/ESE.hpp
+++ b/addons/main/GUI/ESE.hpp
@@ -142,7 +142,11 @@ class ENH_ESE
                         "Backpacks",
                         "Headgear",
                         "Goggles",
-                        "NVGs"
+                        "NVGs",
+                        "Separator",
+                        "ImportToFilter",
+                        "Separator",
+                        "ResetToAllItems"
                     };
                 };
                 class FolderHelp
@@ -398,6 +402,16 @@ class ENH_ESE
                     text = "$STR_A3_RSCDISPLAYARSENAL_TAB_NVGS";
                     picture = "\a3\ui_f\data\gui\rsc\rscdisplayarsenal\nvgs_ca.paa";
                     data = "NVGoggles";
+                };
+                class ImportToFilter
+                {
+                    text = "$STR_ENH_MAIN_ESE_IMPORTFROMCLIPBOARD";
+                    action = "[] call ENH_fnc_ESE_importToFilter";
+                };
+                class ResetToAllItems
+                {
+                    text = "$STR_A3_RSCDISPLAYARSENAL_RESET";
+                    action = "[] call ENH_fnc_ESE_resetToAllItems";
                 };
                 class InventoryItems: ARs
                 {

--- a/addons/main/cfgFunctions.hpp
+++ b/addons/main/cfgFunctions.hpp
@@ -99,6 +99,7 @@ class CfgFunctions
             class ESE_fullArsenal;
             class ESE_getConfigValues;
             class ESE_handleTemplates;
+            class ESE_importToFilter;
             class ESE_lbAdd;
             class ESE_lnbAdd;
             class ESE_loadAttributeValue;
@@ -108,6 +109,7 @@ class CfgFunctions
             class ESE_removeItem;
             class ESE_resetSearch;
             class ESE_resetStorage;
+            class ESE_resetToAllItems;
             class ESE_search;
             class ESE_sort;
             class ESE_toggleVirtual;

--- a/addons/main/functions/GUI/ESE/fn_ESE_importToFilter.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_importToFilter.sqf
@@ -1,0 +1,26 @@
+/*
+    Author: Pixelated_Grunt
+
+    Date: 2024-08-29
+
+    Description:
+    Used by the ENH_ESE GUI. Import a list from clipboard to the available list (left panel).
+    The import list is same as ACE arsenal export format i.e. ["item1", "item2"].
+
+    Parameter(s):
+    -
+
+    Returns:
+    -
+*/
+
+
+#include "\x\enh\addons\main\script_component.hpp"
+private _allAttributes = ([true] call ENH_fnc_ESE_parseClipboardValues)#1;
+
+// Backup the existing ENH_ESE_itemsHashMap
+uiNamespace setVariable ["ENH_ESE_itemsHashMapClone", uiNamespace getVariable ["ENH_ESE_itemsHashMap", createHashMap]];
+// Replace the hashmap
+uiNamespace setVariable ["ENH_ESE_itemsHashMap", _allAttributes];
+// Call change filter to trigger the list update
+[CTRL(IDC_ESE_MENU), [2, 0]] call ENH_fnc_ESE_changeFilter

--- a/addons/main/functions/GUI/ESE/fn_ESE_importToFilter.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_importToFilter.sqf
@@ -16,7 +16,8 @@
 
 
 #include "\x\enh\addons\main\script_component.hpp"
-private _allAttributes = ([true] call ENH_fnc_ESE_parseClipboardValues)#1;
+private _allAttributes = [true] call ENH_fnc_ESE_parseClipboardValues;
+private _display = uiNamespace getVariable ["ENH_Display_ESE", displayNull];
 
 // Backup the existing ENH_ESE_itemsHashMap
 uiNamespace setVariable ["ENH_ESE_itemsHashMapClone", uiNamespace getVariable ["ENH_ESE_itemsHashMap", createHashMap]];

--- a/addons/main/functions/GUI/ESE/fn_ESE_lbAdd.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_lbAdd.sqf
@@ -31,11 +31,12 @@ params
     ["_textRight", ""]
 ];
 
-if (_lbText != "") then {
+if (_lbText != "") then 
+{
     private _index = _ctrlLb lbAdd _lbText;
     _ctrlLb lbSetData [_index, _lbData];
     _ctrlLb lbSetPicture [_index, _pictureLeft];
     _ctrlLb lbSetPictureRight [_index, _pictureRight];
     _ctrlLb lbSetTooltip [_index, _tooltip];
     _ctrlLb lbSetTextRight [_index, _textRight]
-}
+};

--- a/addons/main/functions/GUI/ESE/fn_ESE_lbAdd.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_lbAdd.sqf
@@ -31,9 +31,11 @@ params
     ["_textRight", ""]
 ];
 
-private _index = _ctrlLb lbAdd _lbText;
-_ctrlLb lbSetData [_index, _lbData];
-_ctrlLb lbSetPicture [_index, _pictureLeft];
-_ctrlLb lbSetPictureRight [_index, _pictureRight];
-_ctrlLb lbSetTooltip [_index, _tooltip];
-_ctrlLb lbSetTextRight [_index, _textRight];
+if (_lbText != "") then {
+    private _index = _ctrlLb lbAdd _lbText;
+    _ctrlLb lbSetData [_index, _lbData];
+    _ctrlLb lbSetPicture [_index, _pictureLeft];
+    _ctrlLb lbSetPictureRight [_index, _pictureRight];
+    _ctrlLb lbSetTooltip [_index, _tooltip];
+    _ctrlLb lbSetTextRight [_index, _textRight]
+}

--- a/addons/main/functions/GUI/ESE/fn_ESE_lnbAdd.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_lnbAdd.sqf
@@ -22,20 +22,22 @@
 disableSerialization;
 params ["_ctrlLnb", "_data", "_text", "_image", "_addonIcon", "_value", "_tooltip", "_specificType"];
 
-private _row = _ctrlLnb lnbAddRow ["", _text, str _value, ""];
+if (_text != "") then {
+    private _row = _ctrlLnb lnbAddRow ["", _text, str _value, ""];
 
-//Column #0
-_ctrlLnb lnbSetData [[_row, 0], _data];
-_ctrlLnb lnbSetPicture [[_row, 0], _image];
-_ctrlLnb lnbSetTooltip [[_row, 0], _tooltip];
+    //Column #0
+    _ctrlLnb lnbSetData [[_row, 0], _data];
+    _ctrlLnb lnbSetPicture [[_row, 0], _image];
+    _ctrlLnb lnbSetTooltip [[_row, 0], _tooltip];
 
-//Column #1
-_ctrlLnb lnbSetValue [[_row, 1], _value];
-_ctrlLnb lnbSetData [[_row, 1], _specificType];
+    //Column #1
+    _ctrlLnb lnbSetValue [[_row, 1], _value];
+    _ctrlLnb lnbSetData [[_row, 1], _specificType];
 
-//Column #2 - Count
-_ctrlLnb lnbSetText [[_row, 2], str _value];
+    //Column #2 - Count
+    _ctrlLnb lnbSetText [[_row, 2], str _value];
 
-//Column #3 - Addon Icon
-_ctrlLnb lnbSetPicture [[_row, 3], _addonIcon];
-_ctrlLnb lnbSetData [[_row, 3], _addonIcon];
+    //Column #3 - Addon Icon
+    _ctrlLnb lnbSetPicture [[_row, 3], _addonIcon];
+    _ctrlLnb lnbSetData [[_row, 3], _addonIcon]
+}

--- a/addons/main/functions/GUI/ESE/fn_ESE_lnbAdd.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_lnbAdd.sqf
@@ -22,7 +22,8 @@
 disableSerialization;
 params ["_ctrlLnb", "_data", "_text", "_image", "_addonIcon", "_value", "_tooltip", "_specificType"];
 
-if (_text != "") then {
+if (_text != "") then 
+{
     private _row = _ctrlLnb lnbAddRow ["", _text, str _value, ""];
 
     //Column #0
@@ -40,4 +41,4 @@ if (_text != "") then {
     //Column #3 - Addon Icon
     _ctrlLnb lnbSetPicture [[_row, 3], _addonIcon];
     _ctrlLnb lnbSetData [[_row, 3], _addonIcon]
-}
+};

--- a/addons/main/functions/GUI/ESE/fn_ESE_open.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_open.sqf
@@ -57,6 +57,10 @@ CTRL(IDC_ESE_AVAILABLEITEMSLIST) ctrlAddEventHandler ["LBSelChanged",
     private _itemsHashMap = uiNamespace getVariable ["ENH_ESE_itemsHashMap", createHashMap];
     private _lbCompItems = ctrlParent _lbAvailableItems displayCtrl IDC_ESE_COMPATIBLEITEMSLIST;
 
+    // Use the clone if exist
+    private _clone = uiNamespace getVariable ["ENH_ESE_itemsHashMapClone", nil];
+    if (!isNil("_clone")) then {_itemsHashMap = _clone};
+
     lbClear _lbCompItems;
 
     {

--- a/addons/main/functions/GUI/ESE/fn_ESE_parseClipboardValues.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_parseClipboardValues.sqf
@@ -7,14 +7,15 @@
     Used by the ENH_ESE GUI. Read and convert array from clipboard to inventory attributes.
 
     Parameter(s):
-    -
+    BOOL - true to return variable only. Default is false.
 
     Returns:
-    ARRAY - Result attributes that can be loaded into the inventory screen. Return all if failed.
+    ARRAY - Result attributes that can be loaded into the filter and inventory screens. Return all items if failed.
 */
 
 
 #include "\x\enh\addons\main\script_component.hpp"
+params [["_return", false, [false]]];
 private _importList = call compile copyFromClipboard;
 
 // Verify import list is in correct format
@@ -41,9 +42,6 @@ private _configs = _importList apply {
     }
 };
 
-//private _configValues = ([_configs] call ENH_fnc_ESE_getConfigValues) select 1;
-//private _attributeValue = [true, _configValues] call ENH_fnc_ESE_applyAttribute;
-//
-//_attributeValue
 private _attributeValue = ([_configs] call ENH_fnc_ESE_getConfigValues) select 1;
+if _return exitWith {_attributeValue};
 [true, _attributeValue] call ENH_fnc_ESE_applyAttribute

--- a/addons/main/functions/GUI/ESE/fn_ESE_resetToAllItems.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_resetToAllItems.sqf
@@ -15,6 +15,7 @@
 
 
 #include "\x\enh\addons\main\script_component.hpp"
+private _display = uiNamespace getVariable ["ENH_Display_ESE", displayNull];
 
 // Restore the ENH_ESE_itemsHashMap variable
 uiNamespace setVariable ["ENH_ESE_itemsHashMap", uiNamespace getVariable "ENH_ESE_itemsHashMapClone"];

--- a/addons/main/functions/GUI/ESE/fn_ESE_resetToAllItems.sqf
+++ b/addons/main/functions/GUI/ESE/fn_ESE_resetToAllItems.sqf
@@ -1,0 +1,24 @@
+/*
+    Author: Pixelated_Grunt
+
+    Date: 2024-08-29
+
+    Description:
+    Used by the ENH_ESE GUI. Reset the filter list (left panel) back to all available items.
+
+    Parameter(s):
+    -
+
+    Returns:
+    -
+*/
+
+
+#include "\x\enh\addons\main\script_component.hpp"
+
+// Restore the ENH_ESE_itemsHashMap variable
+uiNamespace setVariable ["ENH_ESE_itemsHashMap", uiNamespace getVariable "ENH_ESE_itemsHashMapClone"];
+// Release the memory
+uiNamespace setVariable ["ENH_ESE_itemsHashMapClone", nil];
+// Call change filter to trigger the list update
+[CTRL(IDC_ESE_MENU), [2, 0]] call ENH_fnc_ESE_changeFilter

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -6873,6 +6873,17 @@
             <Chinese>可用物品</Chinese>
             <Italian>Oggetti Disponibili</Italian>
         </Key>
+        <Key ID="STR_A3_RSCDISPLAYARSENAL_RESET">
+            <English>Reset</English>
+            <Russian>Перезагрузить</Russian>
+            <German>Zurücksetzen</German>
+            <Polish>Nastawić</Polish>
+            <French>Réinitialiser</French>
+            <Spanish>Reiniciar</Spanish>
+            <Chinesesimp>重置</Chinesesimp>
+            <Chinese>重置</Chinese>
+            <Italian>Reset</Italian>
+        </Key>
         <Key ID="STR_ENH_MAIN_ESE_FULLARSENAL_TOOLTIP">
             <English>Adds all items of selected addon to the inventory and sets it to be virtual (Arsenal).</English>
             <Russian>Добавляет все предметы выбранного аддона в инвентарь и делает его виртуальным (Арсенал).</Russian>


### PR DESCRIPTION
This change allows users to import an existing list of items and use ESE to find compatible items. It adds 2 extra options to the 'Filter' menu strip.

- **Import from Clipboard**
  * Import ACE arsenal export format array to the 'Available Items' (existing items will be replaced/removed). Available Items list will stay as the imported list until user hit reset
- **Reset**
  * Reset the 'Available Items' back to all items

This is a simple change by using existing functions to convert clipboard data to have the same data structure as the 'EHN_ENE_itemsHashMap' hashmap. Then replace the 'EHN_ENE_itemsHashMap' variable with the newly created hashmap.

Existing 'EHN_ENE_itemsHashMap' will be saved for the reset function.

==============================================================================

It also adds filters to both 'fn_ESE_lbAdd' and 'fn_ESE_lbnAdd' functions to skip items that are blanks (no Display Text). The ESE list boxes contain blank rows, this behavior exist in the current Steam release as well. See before and after screenshots from the Steam release version.

**BEFORE**
![20240829034628_1](https://github.com/user-attachments/assets/b6b30005-03ce-468f-a3eb-513388d40804)

**AFTER**
![20240829034339_1](https://github.com/user-attachments/assets/2a92102a-fa44-4ec8-bf58-f9b64e22ced3)