### PR TITLE
Fix updating base classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Added InputList attribute control
 - Moved mass attribute from transformation category to state category
 - Moved limit speed attribute from special states category to state category
+- Fixed updating base classes for RscDebugConsole, EditCodeMulti3, and Display3DEN
 
 ## REMOVED
 - Customization via userconfig

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,3 +28,4 @@
 | a1044438870 |
 | Artenis |
 | Pixelated Grunt | minor ESE improvement |
+| Dart | Config |

--- a/addons/main/GUI/RscDebugConsole.hpp
+++ b/addons/main/GUI/RscDebugConsole.hpp
@@ -1,10 +1,10 @@
 class RscControlsGroupNoScrollbars;
+class RscButtonMenu;
 class RscDebugConsole: RscControlsGroupNoScrollbars
 {
     class Controls
     {
-        class ButtonSpectatorCamera;
-        class ButtonFunctions: ButtonSpectatorCamera
+        class ButtonFunctions: RscButtonMenu
         {
             idc = -1;
             //Dynamically reposition it if Connor's functions viewer is available as well.

--- a/addons/main/GUI/RscDebugConsole.hpp
+++ b/addons/main/GUI/RscDebugConsole.hpp
@@ -10,6 +10,9 @@ class RscDebugConsole: RscControlsGroupNoScrollbars
             //Dynamically reposition it if Connor's functions viewer is available as well.
             onLoad = "_this # 0 ctrlSetText ('ENH_' + localize 'STR_A3_RSCDEBUGCONSOLE_BUTTONFUNCTIONS'); if (isClass (configFile >> 'RscDisplayDebugPublic' >> 'Controls' >> 'DebugConsole' >> 'controls' >> 'CAU_xFuncViewer')) then {_this # 0 ctrlSetPosition [7.5 * (((safeZoneW / safeZoneH) min 1.2) / 40), 21.6 * ((((safeZoneW / safeZoneH) min 1.2) / 1.2) / 25)]; _this # 0 ctrlCommit 0;}";
             x = QUOTE(7.5 * GUI_GRID_W);
+            y = QUOTE(19.4 * GUI_GRID_H);
+            w = QUOTE(7.4 * GUI_GRID_W);
+            h = QUOTE(1 * GUI_GRID_H);
             onButtonClick = "ctrlParent (_this # 0) createDisplay 'ENH_FunctionsViewer'";
         };
     };

--- a/addons/main/cfg3DEN.hpp
+++ b/addons/main/cfg3DEN.hpp
@@ -110,6 +110,25 @@ class Cfg3DEN
                 };
             };
         };
+        class EditCodeMulti5: EditMulti5
+        {
+            class Controls: Controls
+            {
+                // Manually apply changes, these aren't inherited for some reason
+                class Background: Background
+                {
+                    h = QUOTE((20 * 3.5 + 0.6 * 5) * GRID_H);
+                };
+                class Value: Value
+                {
+                    h = QUOTE(20 * 3.5 * GRID_H - 1 * GRID_H);
+                };
+                class Title: Title
+                {
+                    h = QUOTE((20 * 3.5 + 1 * 5) * GRID_H);
+                };
+            };
+        };
         #include "controls\SPR.hpp"
         #include "controls\advancedDamage.hpp"
         #include "controls\airdrop.hpp"

--- a/addons/main/cfg3DEN.hpp
+++ b/addons/main/cfg3DEN.hpp
@@ -69,10 +69,13 @@ class Cfg3DEN
             };
         };
         //Increase height of edit attribute controls
-        class Edit;
+        class Edit: Title
+        {
+            class Controls;
+        };
         class EditMulti3: Edit
         {
-            class Controls
+            class Controls: Controls
             {
                 class Value;
                 class Background;
@@ -81,7 +84,7 @@ class Cfg3DEN
         };
         class EditCodeMulti3: EditMulti3
         {
-            class Controls
+            class Controls: Controls
             {
                 class Value;
                 class Background;
@@ -107,7 +110,7 @@ class Cfg3DEN
                 };
             };
         };
-        class EditCodeMulti5: EditCodeMulti3
+        class EditCodeMulti5: EditMulti5
         {
             h = QUOTE((5 + 20 * 3.5) * GRID_H);
             class Controls: Controls

--- a/addons/main/cfg3DEN.hpp
+++ b/addons/main/cfg3DEN.hpp
@@ -110,25 +110,6 @@ class Cfg3DEN
                 };
             };
         };
-        class EditCodeMulti5: EditMulti5
-        {
-            h = QUOTE((5 + 20 * 3.5) * GRID_H);
-            class Controls: Controls
-            {
-                class Background: Background
-                {
-                    h = QUOTE((20 * 3.5 + 0.6 * 5) * GRID_H);
-                };
-                class Value: Value
-                {
-                    h = QUOTE(20 * 3.5 * GRID_H - 1 * GRID_H);
-                };
-                class Title: Title
-                {
-                    h = QUOTE((20 * 3.5 + 1 * 5) * GRID_H);
-                };
-            };
-        };
         #include "controls\SPR.hpp"
         #include "controls\advancedDamage.hpp"
         #include "controls\airdrop.hpp"

--- a/addons/main/display3DEN/display3DEN.hpp
+++ b/addons/main/display3DEN/display3DEN.hpp
@@ -31,17 +31,45 @@ class Display3DEN
                 {
                     w = QUOTE(19 * GRID_W);
                 };
+                // Manually reconfig Version into a button
                 class Version: ValueX
                 {
                     idc = -1;
+                    type = CT_BUTTON;
                     text = "V";
+                    font = "PuristaLight";
+
                     x = QUOTE(ORIGIN_X_STATUSBAR - 15 * GRID_W - SPACE_X);
                     y = QUOTE(2 * pixelH);
                     w = QUOTE(4 * GRID_W - 4 * pixelW);
                     h = QUOTE(4 * GRID_H - 4 * pixelH);
+                    sizeEx = QUOTE(4.32 * SIZEEX_BASE);
+                    offsetX = 0;
+                    offsetY = 0;
+                    offsetPressedX = "pixelW";
+                    offsetPressedY = "pixelH";
+
                     colorBackground[] = {0, 0, 0, 0.5};
+                    colorBackgroundDisabled[] = {0, 0, 0, 0.5};
+                    colorBackgroundActive[] = {COLOR_ACTIVE_RGB, 1};
+                    colorBorder[] = {0, 0, 0, 0};
+                    colorDisabled[] = {1, 1, 1, 0.25};
+                    colorFocused[] = {COLOR_ACTIVE_RGB, 1};
+                    colorShadow[] = {0, 0, 0, 0};
+
                     onLoad = "_this # 0 ctrlSetToolTip format ['%1.%2', (productVersion select 2) * 0.01 toFixed 2, productVersion select 3]";
                     onButtonClick = "call ENH_fnc_productInfo";
+                    soundClick[] = {"\A3\ui_f\data\sound\RscButton\soundClick", 0.09, 1};
+                    soundEnter[] = {"\A3\ui_f\data\sound\RscButton\soundEnter", 0.09, 1};
+                    soundEscape[] = {"\A3\ui_f\data\sound\RscButton\soundEscape", 0.09, 1};
+                    soundPush[] = {"\A3\ui_f\data\sound\RscButton\soundPush", 0.09, 1};
+
+                    borderSize = 0;
+                    period = 0;
+                    periodFocus = 2;
+                    periodOver = 0.5;
+                    style = "0x02 + 0xC0";
+                    shadow = 1;
                 };
                 class TextY: TextX
                 {

--- a/addons/main/display3DEN/display3DEN.hpp
+++ b/addons/main/display3DEN/display3DEN.hpp
@@ -31,7 +31,7 @@ class Display3DEN
                 {
                     w = QUOTE(19 * GRID_W);
                 };
-                class Version: ctrlButton
+                class Version: ValueX
                 {
                     idc = -1;
                     text = "V";


### PR DESCRIPTION
Fix updating the base classes for various classes.
Currently when launching the game, the following errors will be logged to the rpt:
```sqf
11:40:51 Updating base class Controls->, by x\enh\addons\main\config.bin/Cfg3DEN/Attributes/EditMulti3/Controls/ (original a3\3den\config.bin)
11:40:51 Updating base class Controls->, by x\enh\addons\main\config.bin/Cfg3DEN/Attributes/EditCodeMulti3/Controls/ (original a3\3den\config.bin)
11:40:51 Updating base class EditMulti5->EditCodeMulti3, by x\enh\addons\main\config.bin/Cfg3DEN/Attributes/EditCodeMulti5/ (original a3\3den\config.bin)
11:40:51 Updating base class Controls->Controls, by x\enh\addons\main\config.bin/Cfg3DEN/Attributes/EditCodeMulti5/Controls/ (original a3\3den\config.bin)
11:40:51 Updating base class Background->Background, by x\enh\addons\main\config.bin/Cfg3DEN/Attributes/EditCodeMulti5/Controls/Background/ (original a3\3den\config.bin)
11:40:51 Updating base class Value->Value, by x\enh\addons\main\config.bin/Cfg3DEN/Attributes/EditCodeMulti5/Controls/Value/ (original a3\3den\config.bin)
11:40:51 Updating base class Title->Title, by x\enh\addons\main\config.bin/Cfg3DEN/Attributes/EditCodeMulti5/Controls/Title/ (original a3\3den\config.bin)
11:40:51 Updating base class ValueX->ctrlButton, by x\enh\addons\main\config.bin/Display3DEN/Controls/StatusBar/Controls/Version/ (original a3\3den\config.bin)
11:40:51 Updating base class RscButtonMenu->ButtonSpectatorCamera, by x\enh\addons\main\config.bin/RscDebugConsole/Controls/ButtonFunctions/ (original a3\ui_f\config.bin)
```

This PR fixes these errors by correcting the inheritance. For example, `EditCodeMulti5` is supposed to inherit from `EditMulti5`; however 3den Enhanced incorrectly has it inheriting from `EditCodeMulti3`.