### PR TITLE
Extend fn_DeleteCrew

### DIFF
--- a/addons/main/functions/misc/fn_deleteCrew.sqf
+++ b/addons/main/functions/misc/fn_deleteCrew.sqf
@@ -16,7 +16,19 @@
 private _toReplace = get3DENSelected "Object";
 
 {
-    delete3DENEntities crew _x;
+    private _entity = _x;
+    private _attributes = _entity get3DENAttributes "";
+    private _classIdx = _attributes apply {_x#0} find "ItemClass";
+    if (_classIdx == -1) exitWith {};
+
+    private _class = _attributes # _classIdx # 1;
+    
+    delete3DENEntities [_entity];
+
+    private _newEntity = create3DENEntity ["Object", _class, [0,0,0], true];
+    {
+        _newEntity set3DENAttribute _x;
+    } forEach _attributes;
 } forEach _toReplace;
 
 ["ENH_actionPerformed"] call BIS_fnc_3DENNotification;


### PR DESCRIPTION
Now functions for all 3DEN entities. Previously did not work on UAV objects.