### PR TITLE
Improved Hostage Freeing

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,3 +30,4 @@
 | Artenis |
 | Pixelated Grunt | minor ESE improvement |
 | Dart | Config |
+| mrschick |

--- a/addons/main/attributesObject/makeHostage.hpp
+++ b/addons/main/attributesObject/makeHostage.hpp
@@ -13,6 +13,8 @@ class ENH_MakeHostage
             if (_this getVariable ['ENH_isHostage', true]) then\
             {\
                 _this switchMove 'Acts_AidlPsitMstpSsurWnonDnon04';\
+                _this disableAI 'MOVE';\
+                _this setCaptive true;\
                 [\
                 _this,\
                 localize 'STR_A3_OM_SYSTEM_QUEST_HOSTAGEHOLDACTION',\
@@ -28,6 +30,10 @@ class ENH_MakeHostage
                     [_target, _actionId] remoteExec ['BIS_fnc_holdActionRemove', 0];\
                     _target setVariable ['ENH_IsHostage', false, true];\
                     _target setVariable ['ENH_WasFreedBy', _caller, true];\
+                    _target enableAI 'MOVE';\
+                    [_target] join (group _caller);\
+                    doStop _target;\
+                    _target setCaptive false;\
                 }\
                 ] call BIS_fnc_holdActionAdd;\
             };\


### PR DESCRIPTION
Added some small features to improve the "Make Hostage" option.
- Hostage will automatically be placed in the captive state, as well as out of it when freed, so that they aren't engaged by nearby AI.
- `"MOVE"` AI will be disabled while tied up, to prevent the hostage from turning around to look at nearby units.
- When freed, the hostage will automatically join the player's group and run a `doStop`, preventing it from running around on its own until commanded to regroup or move to a new location by the group's leader.