### PR TITLE
Translate new AI command strings in all languages

### DIFF
--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -4988,6 +4988,32 @@
             <Chinese>禁用AI索敵能力</Chinese>
             <Chinesesimp>禁用AI索敌能力</Chinesesimp>
         </Key>
+        <Key ID="STR_ENH_MAIN_DISABLEAI_COMMAND_DISPLAYNAME">
+            <English>Command</English>
+            <Czech>Příkaz</Czech>
+            <French>Commande</French>
+            <Spanish>Comando</Spanish>
+            <Italian>Comando</Italian>
+            <Polish>Polecenie</Polish>
+            <Portuguese>Comando</Portuguese>
+            <Russian>Команда</Russian>
+            <German>Befehl</German>
+            <Chinese>命令</Chinese>
+            <Chinesesimp>命令</Chinesesimp>
+        </Key>
+        <Key ID="STR_ENH_MAIN_DISABLEAI_COMMAND_TOOLTIP">
+            <English>Disables AI's ability to issue commands.</English>
+            <Czech>Zakáže AI vydávání příkazů.</Czech>
+            <French>Désactive la capacité de l'IA à émettre des commandes.</French>
+            <Spanish>Deshabilita la capacidad de la IA para emitir comandos.</Spanish>
+            <Italian>Disabilita la capacità dell'IA di emettere comandi.</Italian>
+            <Polish>Wyłącza możliwość AI wydawania poleceń.</Polish>
+            <Portuguese>Desativa a capacidade da IA de emitir comandos.</Portuguese>
+            <Russian>Отключает способность ИИ отдавать команды.</Russian>
+            <German>Deaktiviert die Fähigkeit der KI, Befehle auszugeben.</German>
+            <Chinese>禁用AI发出命令的能力。</Chinese>
+            <Chinesesimp>禁用AI发出命令的能力。</Chinesesimp>
+        </Key>
         <Key ID="STR_ENH_MAIN_DISABLEAI_TEAMSWITCH_DISPLAYNAME">
             <English>Team Switch</English>
             <Czech>Přepínání jednotek v týmu</Czech>


### PR DESCRIPTION
This pull request adds translations for the new strings `STR_ENH_MAIN_DISABLEAI_COMMAND_DISPLAYNAME` and `STR_ENH_MAIN_DISABLEAI_COMMAND_TOOLTIP` in the `stringtable.xml` file. 

Changes include:
- Added translations for the new strings in all languages present in the stringtable. 
- Ensured consistency and completeness of translations across different languages. 

These updates enhance the user experience by providing localized command names and tooltips for the new AI command feature.